### PR TITLE
Multi community support & Option to show legacy devices

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,13 +14,50 @@
 /*
     15.05.20 TS: initial commit
 */
+
+//Helper function
+function getQueryVariable(variable)
+{
+       var query = window.location.search.substring(1);
+       var vars = query.split("&");
+       for (var i=0;i<vars.length;i++) {
+               var pair = vars[i].split("=");
+               if(pair[0] == variable){return pair[1];}
+       }
+       return(false);
+}
+
+//Available domain_prefix
+const available_domain_prefixs = {'ffwsn':"Freifunk Weinstraße Nord",
+                                  'ffwss':"Freifunk Weinstraße Süd",
+                                  'ffaw':"Freifunk Alzey-Worms", 
+                                  'ffso':"Freifunk Soonwald", 
+                                  'ffwy':"Freifunk Weyher", 
+                                  'ffvp':"Freifunk Vorderpfalz",
+                                   };
+
+//Build domain_setting
+var community = getQueryVariable('community');
+if (available_domain_prefixs[community] != null){
+  var domain_prefix = community;
+  var verbose_name  = available_domain_prefixs[community];
+} else {
+  var domain_prefix = 'ffwsn';
+  var verbose_name = "Freifunk Weinstraße Nord";
+}
+
+//ffsw global settings
+var firmware_base_path = `/fw/${domain_prefix}`;
+const fw_stages = {'stable':'stable','pilot':'stable.pilot'};
+const fw_types = ['factory','other','sysupgrade'];
+
 var config = {
   // list images on console that match no model
   listMissingImages: false,
   // see devices.js for different vendor model maps
   vendormodels: vendormodels,
   // set enabled categories of devices (see devices.js)
-  enabled_device_categories: ["recommended"],
+  enabled_device_categories: ["recommended", "ath10k_lowmem", "small_kernel_part", "4_32",  "8_32"],
   // Display a checkbox that allows to display not recommended devices.
   // This only make sense if enabled_device_categories also contains not
   // recommended devices.
@@ -28,22 +65,17 @@ var config = {
   // Optional link to an info page about no longer recommended devices
   recommended_info_link: null,
   // community prefix of the firmware images
-  community_prefix: 'gluon-ffwsn-ffwsn-v',
+  community_prefix: `gluon-${domain_prefix}-${domain_prefix}-v`,
   // firmware version regex
   version_regex: '-([0-9]{3})?[.-]',
   //version_regex: '-(v[0-9]{3})?[.-]',
   // relative image paths and branch
   directories: {
     // some demo sources
-    '/fw/ffwsn/stable/factory/': 'stable',
-    '/fw/ffwsn/stable/other/': 'stable',
-    '/fw/ffwsn/stable/sysupgrade/': 'stable',
-    '/fw/ffwsn/stable.pilot/factory/':'pilot',
-    '/fw/ffwsn/stable.pilot/other/':'pilot',
-    '/fw/ffwsn/stable.pilot/sysupgrade/':'pilot',
+    // GENERATED
   },
   // page title
-  title: 'Freifunk Weinstrasse Nord Firmware',
+  title:`${verbose_name} Firmware`,
   // branch descriptions shown during selection
   branch_descriptions: {
     stable: 'Gut getestet, zuverlässig und stabil.',
@@ -59,3 +91,11 @@ var config = {
   // link to changelog
   changelog: 'https://freifunk-suedwest.de/firmware-versionen/'
 };
+
+//Generate firmware directories
+for (const[stage, folder] of Object.entries(fw_stages)){ // stages: {stable:stable pilot:stable_pilot} ...
+  for (let i=0; i<fw_types.length; i++) { // type: [factory, sysuograde, other] ...
+    config.directories[firmware_base_path +'/'+ folder +'/'+ fw_types[i]+ "/"] = stage;
+  }
+}
+


### PR DESCRIPTION
Config can be used for ffsw multi community setups. Community prefix has to be registered in config " available_domain_prefixs" dict and can then be passed to the application within the ''community' query parameter.